### PR TITLE
fix: value replaced with modelValue

### DIFF
--- a/src/components/.npmrc
+++ b/src/components/.npmrc
@@ -1,0 +1,1 @@
+node-options="--openssl-legacy-provider"

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -41,9 +41,6 @@ export default {
         this.onMenuClose()
       }
     },
-    'instance.forest'(newValue) {
-      console.log('instance forest', newValue);
-    }
   },
 
   created() {

--- a/src/mixins/treeselectMixin.js
+++ b/src/mixins/treeselectMixin.js
@@ -851,6 +851,16 @@ export default {
       this.initialize()
     },
 
+    modelValue: {
+      deep: true,
+      handler() {
+        const nodeIdsFromValue = this.extractCheckedNodeIdsFromValue()
+        const hasChanged = quickDiff(nodeIdsFromValue, this.internalValue)
+        if (!hasChanged) return
+        this.fixSelectedNodeIds(nodeIdsFromValue)
+      },
+    },
+
     multiple(newValue) {
       // We need to rebuild the state when switching from single-select mode
       // to multi-select mode.
@@ -877,12 +887,6 @@ export default {
       }
 
       this.$emit('search-change', this.trigger.searchQuery, this.getInstanceId())
-    },
-
-    value() {
-      const nodeIdsFromValue = this.extractCheckedNodeIdsFromValue()
-      const hasChanged = quickDiff(nodeIdsFromValue, this.internalValue)
-      if (hasChanged) this.fixSelectedNodeIds(nodeIdsFromValue)
     },
   },
 
@@ -1286,7 +1290,6 @@ export default {
         this.initialize()
         this.resetHighlightedOptionWhenNecessary(true)
       }
-      console.log(searchQuery, this.minChar);
       if (((searchQuery === "" && this.minChar > 0) || this.cacheOptions) && entry.isLoaded) {
         return done()
       }
@@ -1476,7 +1479,6 @@ export default {
       this.$nextTick(this.resetHighlightedOptionWhenNecessary)
       this.$nextTick(this.restoreMenuScrollPosition)
       if (!this.options && !this.async) this.loadRootOptions()
-      console.log(this.minChar);
       if (this.minChar == 0 && this.async) this.handleRemoteSearch();
       this.toggleClickOutsideEvent(true)
       this.$emit('open', this.getInstanceId())


### PR DESCRIPTION
Vue 3 uses modelValue instead of value in Vue 2.

If the parent component changes modelValue, Treeselect does not trigger an update because the `value` property has been set to watch. Now this is the `modelValue`.

Additionaly: 
1. added flag for npm. This change allows you to work with Node.js v18+
2. all console.log removed